### PR TITLE
Add AppVeyor CI configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: 1.0.{build}-{branch}
+
+branches:
+  except:
+    - gh-pages
+
+image: Visual Studio 2015
+
+init:
+  - git config --global core.autocrlf input
+
+clone_folder: c:\projects\clibspi
+
+platform:
+  - x86
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+build:
+  parallel: true
+  verbosity: normal
+
+build_script:
+  - cmd: if "%platform%"=="x86" build32.bat
+  - cmd: if "%platform%"=="x64" build64.bat


### PR DESCRIPTION
Turn on [AppVeyor](https://ci.appveyor.com/) before you merge this pull request.

AppVeyor is Windows-based CI tool. Build status of my fork is [there](https://ci.appveyor.com/project/Roman3349/clibspi).

Signed-off-by: Roman3349 ondracek.roman@centrum.cz